### PR TITLE
feat: add initial VPC support for networking service

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -410,11 +410,6 @@ func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 	return initClientOpts(client, eo, "volumev3")
 }
 
-// NewVPC creates a ServiceClient that may be used to access the v3 block storage service.
-func NewVPC(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	return initClientOpts(client, eo, "vpc")
-}
-
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo, "sharev2")

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -410,6 +410,11 @@ func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 	return initClientOpts(client, eo, "volumev3")
 }
 
+// NewVPC creates a ServiceClient that may be used to access the v3 block storage service.
+func NewVPC(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "vpc")
+}
+
 // NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
 func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo, "sharev2")

--- a/openstack/networking/v2/vpcs/requests.go
+++ b/openstack/networking/v2/vpcs/requests.go
@@ -61,7 +61,6 @@ type CreateOpts struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
 	CIDR        string `json:"cidr,omitempty"`
-	ProjectID   string `json:"project_id,omitempty"`
 }
 
 // ToVPCCreateMap formats a CreateOpts struct into a request body.

--- a/openstack/networking/v2/vpcs/results.go
+++ b/openstack/networking/v2/vpcs/results.go
@@ -55,6 +55,7 @@ type VPC struct {
 	CreatedAt   string `json:"created_at"`
 	UpdatedAt   string `json:"updated_at"`
 	ProjectID   string `json:"project_id"`
+	Status      string `json:"status"`
 }
 
 func (r *VPC) UnmarshalJSON(b []byte) error {

--- a/openstack/networking/v2/vpcs/results.go
+++ b/openstack/networking/v2/vpcs/results.go
@@ -1,6 +1,9 @@
 package vpcs
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/vnpaycloud-console/gophercloud/v2"
 	"github.com/vnpaycloud-console/gophercloud/v2/pagination"
 )
@@ -46,19 +49,54 @@ type DeleteResult struct {
 
 // VPC represents, well, a VPC.
 type VPC struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	CIDR        string `json:"cidr"`
-	SNATAddress string `json:"snat_address"`
-	EnableSNAT  bool   `json:"enable_snat"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
-	ProjectID   string `json:"project_id"`
-	Status      string `json:"status"`
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CIDR        string    `json:"cidr"`
+	SNATAddress string    `json:"snat_address"`
+	EnableSNAT  bool      `json:"enable_snat"`
+	Region      string    `json:"region"`
+	UpdatedAt   time.Time `json:"-"`
+	CreatedAt   time.Time `json:"-"`
+	ProjectID   string    `json:"project_id"`
+	Status      string    `json:"status"`
 }
 
 func (r *VPC) UnmarshalJSON(b []byte) error {
+	type tmp VPC
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = VPC(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = VPC(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
 	return nil
 }
 


### PR DESCRIPTION
This merge request introduces support for the Virtual Private Cloud (VPC) resource in the networking service of VNPAY Gophercloud. The implementation includes:

- VPC create, get, update, delete, and list operations
- Basic request/response struct definitions following OpenStack SDK conventions
- Integration tests for CRUD operations
- Documentation for using the new VPC client

This addition allows users to manage virtual private cloud networks programmatically via Gophercloud, aligning with recent API updates on compatible OpenStack deployments.