### PR TITLE
feat(vpc): add status filter to ListOpts

### DIFF
--- a/openstack/networking/v2/vpcs/requests.go
+++ b/openstack/networking/v2/vpcs/requests.go
@@ -18,6 +18,7 @@ type ListOpts struct {
 	ID        string `q:"id"`
 	ProjectID string `q:"project_id"`
 	Limit     int    `q:"limit"`
+	Status    string `q:"status"`
 }
 
 // ToVPCListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
This update enhances the VPC listing functionality by adding a `Status` field to the `ListOpts` struct. It allows clients to filter VPCs by their current status when querying via the List API.

Changes include:
- New `Status` field in `ListOpts`
- URL query parameter support for status filtering

This change improves the efficiency of client applications that need to query VPCs in specific lifecycle states, such as OS_ACTIVE or OS_FAILED.
