### PR TITLE
feat(subnet): expose vpc_id in Subnet structs

### DIFF
--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -42,6 +42,7 @@ type ListOpts struct {
 	TagsAny           string `q:"tags-any"`
 	NotTags           string `q:"not-tags"`
 	NotTagsAny        string `q:"not-tags-any"`
+	VPCID             string `q:"vpc_id"`
 }
 
 // ToSubnetListQuery formats a ListOpts into a query string.
@@ -146,6 +147,8 @@ type CreateOpts struct {
 	// Prefixlen is used when user creates a subnet from the subnetpool. It will
 	// overwrite the "default_prefixlen" value of the referenced subnetpool.
 	Prefixlen int `json:"prefixlen,omitempty"`
+
+	VPCID string `json:"vpc_id,omitempty"`
 }
 
 // ToSubnetCreateMap builds a request body from CreateOpts.

--- a/openstack/networking/v2/subnets/results.go
+++ b/openstack/networking/v2/subnets/results.go
@@ -121,6 +121,8 @@ type Subnet struct {
 
 	// RevisionNumber optionally set via extensions/standard-attr-revisions
 	RevisionNumber int `json:"revision_number"`
+
+	VPCID string `json:"vpc_id"`
 }
 
 // SubnetPage is the page returned by a pager when traversing over a collection


### PR DESCRIPTION
This merge request adds support for the `vpc_id` field in the `Subnet` struct and the `CreateOpts`, `ListOpts` structs.

Changes include:
- Add `VpcID` field to `subnets.Subnet` to expose the VPC associated with a subnet
- Add `VpcID` to `subnets.CreateOpts` to allow specifying the VPC during subnet creation
- Update request body construction to include `vpc_id` when present

These changes enable clients to both view and assign the VPC relationship for subnets through the SDK, improving support for VPC-aware networking workflows.