### PR TITLE
feat(networking): initial support for VPC peering resources

### DIFF
--- a/openstack/networking/v2/peeringconnectionapprovals/requests.go
+++ b/openstack/networking/v2/peeringconnectionapprovals/requests.go
@@ -1,0 +1,77 @@
+package peeringconnectionapprovals
+
+import (
+	"context"
+
+	"github.com/vnpaycloud-console/gophercloud/v2"
+	"github.com/vnpaycloud-console/gophercloud/v2/pagination"
+)
+
+type ListOptsBuilder interface {
+	ToPeeringConnectionApprovalListQuery() (string, error)
+}
+
+type ListOpts struct {
+	PeerVPCId string `q:"src_vpc_id,omitempty"`
+	PeerOrgId string `q:"src_org_id,omitempty"`
+	VPCId     string `q:"dest_vpc_id,omitempty"`
+	Status    string `q:"status,omitempty"`
+}
+
+func (opts ListOpts) ToPeeringConnectionApprovalListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToPeeringConnectionApprovalListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return PeeringConnectApprovalPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+type UpdateOptsBuilder interface {
+	ToPeeringConnectionApprovalUpdateMap() (map[string]any, error)
+}
+
+type UpdateOpts struct {
+	Accept bool `json:"is_allowed,omitempty"`
+}
+
+func (opts UpdateOpts) ToPeeringConnectionApprovalUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "peering_connection_approval")
+}
+
+func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPeeringConnectionApprovalUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := c.Put(ctx, updateURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		MoreHeaders: h,
+		OkCodes:     []int{200, 201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/peeringconnectionapprovals/results.go
+++ b/openstack/networking/v2/peeringconnectionapprovals/results.go
@@ -1,0 +1,94 @@
+package peeringconnectionapprovals
+
+import (
+	"encoding/json"
+
+	"github.com/vnpaycloud-console/gophercloud/v2"
+	"github.com/vnpaycloud-console/gophercloud/v2/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+func (r commonResult) Extract() (*PeeringConnectApproval, error) {
+	var s PeeringConnectApproval
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v any) error {
+	return r.Result.ExtractIntoStructPtr(v, "peering_connection_approval")
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+type PeeringConnectApproval struct {
+	ID          string `json:"id"`
+	PeerId      string `json:"peering_connection_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	VpcId       string `json:"src_vpc_id"`
+	PeerOrgId   string `json:"dest_org_id"`
+	PeerVpcId   string `json:"dest_vpc_id"`
+	Status      string `json:"status"`
+}
+
+func (r *PeeringConnectApproval) UnmarshalJSON(b []byte) error {
+	type tmp PeeringConnectApproval
+	var s struct {
+		tmp
+	}
+
+	err := json.Unmarshal(b, &s)
+
+	if err != nil {
+		return err
+	}
+
+	*r = PeeringConnectApproval(s.tmp)
+
+	return nil
+}
+
+type PeeringConnectApprovalPage struct {
+	pagination.LinkedPageBase
+}
+
+func (r PeeringConnectApprovalPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"peering_connection_approvals_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+func (r PeeringConnectApprovalPage) IsEmpty() (bool, error) {
+	vpcs, err := ExtractPeeringConnectApprovals(r)
+	if err != nil {
+		return true, err
+	}
+	return len(vpcs) == 0, nil
+}
+
+func ExtractPeeringConnectApprovals(r pagination.Page) ([]PeeringConnectApproval, error) {
+	var s []PeeringConnectApproval
+	err := ExtractPeeringConnectApprovalsInto(r, &s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func ExtractPeeringConnectApprovalsInto(r pagination.Page, v any) error {
+	return r.(PeeringConnectApprovalPage).ExtractIntoSlicePtr(v, "peering_connection_approvals")
+}

--- a/openstack/networking/v2/peeringconnectionapprovals/urls.go
+++ b/openstack/networking/v2/peeringconnectionapprovals/urls.go
@@ -1,0 +1,23 @@
+package peeringconnectionapprovals
+
+import "github.com/vnpaycloud-console/gophercloud/v2"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("peering-connection-approvals", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("peering-connection-approvals")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/openstack/networking/v2/peeringconnectionrequests/requests.go
+++ b/openstack/networking/v2/peeringconnectionrequests/requests.go
@@ -1,0 +1,67 @@
+package peeringconnectionrequests
+
+import (
+	"context"
+
+	"github.com/vnpaycloud-console/gophercloud/v2"
+	"github.com/vnpaycloud-console/gophercloud/v2/pagination"
+)
+
+type ListOptsBuilder interface {
+	ToPeeringConnectionRequestListQuery() (string, error)
+}
+
+type ListOpts struct {
+}
+
+func (opts ListOpts) ToPeeringConnectionRequestListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToPeeringConnectionRequestListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return PeeringConnectionRequestPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+type CreateOptsBuilder interface {
+	ToPeeringConnectionCreateMap() (map[string]any, error)
+}
+
+type CreateOpts struct {
+	PeerVPCId   string `json:"dest_vpc_id,omitempty"`
+	PeerOrgId   string `json:"dest_org_id,omitempty"`
+	VPCId       string `json:"src_vpc_id,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+func (opts CreateOpts) ToPeeringConnectionCreateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "peering_connection_request")
+}
+
+func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPeeringConnectionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := c.Post(ctx, createURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/peeringconnectionrequests/results.go
+++ b/openstack/networking/v2/peeringconnectionrequests/results.go
@@ -1,0 +1,95 @@
+package peeringconnectionrequests
+
+import (
+	"encoding/json"
+
+	"github.com/vnpaycloud-console/gophercloud/v2"
+	"github.com/vnpaycloud-console/gophercloud/v2/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+func (r commonResult) Extract() (*PeeringConnectionRequest, error) {
+	var s PeeringConnectionRequest
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v any) error {
+	return r.Result.ExtractIntoStructPtr(v, "peering_connection_request")
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type PeeringConnectionRequest struct {
+	ID             string `json:"id"`
+	RequestStatus  string `json:"request_status"`
+	PeerId         string `json:"peering_connection_id"`
+	Description    string `json:"description"`
+	ConnectionType string `json:"connection_type"`
+	Status         string `json:"status"`
+	VpcId          string `json:"src_vpc_id"`
+	PeerOrgId      string `json:"dest_org_id"`
+	PeerVpcId      string `json:"dest_vpc_id"`
+}
+
+func (r *PeeringConnectionRequest) UnmarshalJSON(b []byte) error {
+	type tmp PeeringConnectionRequest
+	var s struct {
+		tmp
+	}
+
+	err := json.Unmarshal(b, &s)
+
+	if err != nil {
+		return err
+	}
+
+	*r = PeeringConnectionRequest(s.tmp)
+
+	return nil
+}
+
+type PeeringConnectionRequestPage struct {
+	pagination.LinkedPageBase
+}
+
+func (r PeeringConnectionRequestPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"peering_connection_requests_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+func (r PeeringConnectionRequestPage) IsEmpty() (bool, error) {
+	vpcs, err := ExtractPeeringConnectionRequests(r)
+	if err != nil {
+		return true, err
+	}
+	return len(vpcs) == 0, nil
+}
+
+func ExtractPeeringConnectionRequests(r pagination.Page) ([]PeeringConnectionRequest, error) {
+	var s []PeeringConnectionRequest
+	err := ExtractPeeringConnectionRequestsInto(r, &s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func ExtractPeeringConnectionRequestsInto(r pagination.Page, v any) error {
+	return r.(PeeringConnectionRequestPage).ExtractIntoSlicePtr(v, "peering_connection_requests")
+}

--- a/openstack/networking/v2/peeringconnectionrequests/urls.go
+++ b/openstack/networking/v2/peeringconnectionrequests/urls.go
@@ -1,0 +1,23 @@
+package peeringconnectionrequests
+
+import "github.com/vnpaycloud-console/gophercloud/v2"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("peering-connection-requests", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("peering-connection-requests")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}

--- a/openstack/networking/v2/peeringconnections/requests.go
+++ b/openstack/networking/v2/peeringconnections/requests.go
@@ -1,0 +1,78 @@
+package peeringconnections
+
+import (
+	"context"
+
+	"github.com/vnpaycloud-console/gophercloud/v2"
+	"github.com/vnpaycloud-console/gophercloud/v2/pagination"
+)
+
+type ListOptsBuilder interface {
+	ToPeeringConnectionListQuery() (string, error)
+}
+
+type ListOpts struct {
+}
+
+func (opts ListOpts) ToPeeringConnectionListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToPeeringConnectionListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return PeeringConnectionPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(ctx, getURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+type UpdateOptsBuilder interface {
+	ToPeeringConnectionUpdateMap() (map[string]any, error)
+}
+
+type UpdateOpts struct {
+}
+
+func (opts UpdateOpts) ToPeeringConnectionUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "peering-connection")
+}
+
+func Update(ctx context.Context, c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPeeringConnectionUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := c.Put(ctx, updateURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		MoreHeaders: h,
+		OkCodes:     []int{200, 201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+func Delete(ctx context.Context, c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(ctx, deleteURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/peeringconnections/results.go
+++ b/openstack/networking/v2/peeringconnections/results.go
@@ -1,0 +1,98 @@
+package peeringconnections
+
+import (
+	"encoding/json"
+
+	"github.com/vnpaycloud-console/gophercloud/v2"
+	"github.com/vnpaycloud-console/gophercloud/v2/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+func (r commonResult) Extract() (*PeeringConnection, error) {
+	var s PeeringConnection
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v any) error {
+	return r.Result.ExtractIntoStructPtr(v, "peering_connection")
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+type PeeringConnection struct {
+	ID             string `json:"id"`
+	PeerStatus     string `json:"peering_status"`
+	Description    string `json:"description"`
+	ConnectionType string `json:"connection_type"`
+	Status         string `json:"status"`
+	VpcId          string `json:"src_vpc_id"`
+	PeerOrgId      string `json:"dest_org_id"`
+	PeerVpcId      string `json:"dest_vpc_id"`
+}
+
+func (r *PeeringConnection) UnmarshalJSON(b []byte) error {
+	type tmp PeeringConnection
+	var s struct {
+		tmp
+	}
+
+	err := json.Unmarshal(b, &s)
+
+	if err != nil {
+		return err
+	}
+
+	*r = PeeringConnection(s.tmp)
+
+	return nil
+}
+
+type PeeringConnectionPage struct {
+	pagination.LinkedPageBase
+}
+
+func (r PeeringConnectionPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"peering_connections_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+func (r PeeringConnectionPage) IsEmpty() (bool, error) {
+	peeringConnections, err := ExtractPeeringConnections(r)
+	if err != nil {
+		return true, err
+	}
+	return len(peeringConnections) == 0, nil
+}
+
+func ExtractPeeringConnections(r pagination.Page) ([]PeeringConnection, error) {
+	var s []PeeringConnection
+	err := ExtractPeeringConnectionsInto(r, &s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func ExtractPeeringConnectionsInto(r pagination.Page, v any) error {
+	return r.(PeeringConnectionPage).ExtractIntoSlicePtr(v, "peering_connections")
+}

--- a/openstack/networking/v2/peeringconnections/urls.go
+++ b/openstack/networking/v2/peeringconnections/urls.go
@@ -1,0 +1,27 @@
+package peeringconnections
+
+import "github.com/vnpaycloud-console/gophercloud/v2"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("peering-connections", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("peering-connections")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
This MR adds support for VPC peering in the networking module, including:

- `peeringconnections`
- `peeringconnectionrequests`
- `peeringconnectionapprovals`

Each resource includes:
- Request and response structs
- URL builders
- Basic operation definitions

These additions enable clients to manage VPC peering workflows via VNPAY Gophercloud.
